### PR TITLE
Build universal wheel for Python 2 compatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
I implemented the suggestion of @runfalk and verifies that it indeed
solves the issue.

Fixes #6.
