### PR TITLE
Fix error when highlighting a plaintext `lang`

### DIFF
--- a/lektor_markdown_highlighter.py
+++ b/lektor_markdown_highlighter.py
@@ -26,7 +26,7 @@ class MarkdownHighlighterPlugin(Plugin):
     def on_markdown_config(self, config, **extra):
         class HighlightMixin(object):
             def block_code(ren, text, lang=None):
-                if not lang:
+                if not lang or lang == 'plaintext':
                     return super(HighlightMixin, ren).block_code(text, lang)
                 return self.highlight_code(text, lang)
         config.renderer_mixins.append(HighlightMixin)


### PR DESCRIPTION
A code block with no specified lexer name is given a `lang` of
'plaintext'. Attempting to highlight a plaintext lang block causes an
error in the lektor build process.

I think this might have been a change in mistune. It looks like that's what the original `if not lang` was doing, so I assume at one point plaintext blocks were `None`.