### PR TITLE
Fix background color

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,26 @@ lektor plugins add markdown-highlighter
 
 The plugin has a config file that is used to configure a few things
 for Pygments.  Just create a file named `markdown-highlighter.ini` into your
-`configs/` folder.  Currently only `pygments.style` is used:
+`configs/` folder.
+
+You can use `pygments.style` to select any of the built-in Pygments styles:
 
 ```ini
 [pygments]
 style = tango
 ```
 
-You can use this to select any of the built-in Pygments styles.  Support for
-custom styles will come in the future.
+Support for custom styles will come in the future.
+
+You can also use `pygments.cssclass` to apply a custom CSS class
+to the generated html and CSS:
+
+```ini
+[pygments]
+cssclass = mycode
+```
+
+By default the plugin will use `highlight` for the CSS class.
 
 The config file is considered the "source" for the Pygments stylesheet, so you must create the configuration file (it can be empty) or Lektor's build will prune `pygments.css`.
 

--- a/lektor_markdown_highlighter.py
+++ b/lektor_markdown_highlighter.py
@@ -12,8 +12,11 @@ class MarkdownHighlighterPlugin(Plugin):
     name = 'Markdown Highlighter'
     description = 'Lektor plugin that adds syntax highlighting for markdown blocks with Pygments.'
 
+    def get_cssclass(self):
+        return self.get_config().get('pygments.cssclass', 'highlight')
+
     def get_formatter(self):
-        return HtmlFormatter(style=self.get_style())
+        return HtmlFormatter(style=self.get_style(), cssclass=self.get_cssclass())
 
     def get_style(self):
         return self.get_config().get('pygments.style', 'default')
@@ -38,7 +41,7 @@ class MarkdownHighlighterPlugin(Plugin):
                 self.config_filename])
             def build_stylesheet(artifact):
                 with artifact.open('w') as f:
-                    f.write(self.get_formatter().get_style_defs(".highlight"))
+                    f.write(self.get_formatter().get_style_defs(f'.{self.get_cssclass()}'))
             return artifact_name
 
         def pygmentize(text, lang):

--- a/lektor_markdown_highlighter.py
+++ b/lektor_markdown_highlighter.py
@@ -13,7 +13,7 @@ class MarkdownHighlighterPlugin(Plugin):
     description = 'Lektor plugin that adds syntax highlighting for markdown blocks with Pygments.'
 
     def get_formatter(self):
-        return HtmlFormatter(style=self.get_style(), cssclass="hll")
+        return HtmlFormatter(style=self.get_style())
 
     def get_style(self):
         return self.get_config().get('pygments.style', 'default')
@@ -38,7 +38,7 @@ class MarkdownHighlighterPlugin(Plugin):
                 self.config_filename])
             def build_stylesheet(artifact):
                 with artifact.open('w') as f:
-                    f.write(self.get_formatter().get_style_defs())
+                    f.write(self.get_formatter().get_style_defs(".highlight"))
             return artifact_name
 
         def pygmentize(text, lang):


### PR DESCRIPTION
Dug into pygments a bit while trying to figure out why the background color wasn't showing on my code blocks. I discovered the need to specify the CSS class in the `get_style_defs` call so it'll be added to the CSS selectors.

Without the arg to `get_style_defs('.highlight')`, this line wasn't present in the generated CSS (I assume because there would've been no selector for it):

```css
.highlight { background: #242933; color: #d8dee9 }
```

Also, since I want to be able to specify a custom CSS class, I added an optional config entry for `pygments.cssclass`. This could also support those who may have existing styles selecting for the previously-used  `.hll` selector.

Resolves #12 